### PR TITLE
Handle custom calibration + limit definitions

### DIFF
--- a/glimmondb/glimmondb.py
+++ b/glimmondb/glimmondb.py
@@ -135,6 +135,10 @@ def read_glimmon(filename='/home/greta/AXAFSHARE/dec/G_LIMMON.dec'):
                 name = words[1]
                 glimmon.update({name: {}})
 
+            elif (words[0] == 'MMSID'):
+                name = words[1]
+                glimmon.update({name: {}})
+
             elif words[0] == 'MLIMIT':
                 setnum = int(words[2])
                 glimmon[name].update({setnum: {}})

--- a/glimmondb/version.py
+++ b/glimmondb/version.py
@@ -1,3 +1,3 @@
 __all__ = ['__version__']
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'


### PR DESCRIPTION
This fixes a bug where limits were incorrectly imported when custom calibrations are placed within the limit definition section rather than before any limit definitions.