### PR TITLE
Fix states switchstates

### DIFF
--- a/glimmon_archive_cron.py
+++ b/glimmon_archive_cron.py
@@ -105,7 +105,7 @@ if __name__ == '__main__':
             new_revision[0], new_revision[1]))
         print(f"{datestring}: New G_LIMMON.dec file copied")
 
-        tdbs = pickle.load(open(tdbfile, 'r'))
+        tdbs = pickle.load(open(tdbfile, 'rb'))
         glimmondb.merge_new_glimmon_to_db(newfile, tdbs)
         print(f"{datestring}:New G_LIMMON.dec merged into sqlite database")
 

--- a/glimmondb/glimmondb.py
+++ b/glimmondb/glimmondb.py
@@ -324,9 +324,9 @@ def fill_states(tdb, g, msid):
 
         if 'es_switch' in list(tdb[msid].keys()):
             for setkey in states['setkeys']:  # assuming there are limit switch states for each set
-                charkey = str(setkey + 1)
+                intkey = setkey + 1
                 try:
-                    states[setkey]['switchstate'] = tdb[msid]['es_switch'][charkey]['state_code']
+                    states[setkey]['switchstate'] = tdb[msid]['es_switch'][intkey]['state_code']
                 except:
                     states[setkey]['switchstate'] = 'none'
 

--- a/glimmondb/version.py
+++ b/glimmondb/version.py
@@ -1,3 +1,3 @@
 __all__ = ['__version__']
 
-__version__ = '0.6.0'
+__version__ = '0.7.0'


### PR DESCRIPTION
This fixes an issue that caused expected states with switched states to not read in the switchstate values. A fix to the cron script was also made to read in the TDB as a binary file.