### PR TITLE
Add tests, structured logging, better database change fingerprinting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore local testing data and Python cache
+testing_data/
+__pycache__/
+*.pyc
+
+# OS/editor cruft
+.DS_Store
+.idea/
+.vscode/

--- a/backup_glimmon.py
+++ b/backup_glimmon.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Backup helper for G_LIMMON.dec files.
+
+Given a source directory and destination directory, this script computes a SHA-256
+fingerprint of the source G_LIMMON.dec file. If the hash differs from the last
+recorded hash, it copies the file to the destination with the hash and UTC
+timestamp appended to the filename.
+
+Usage:
+    python backup_glimmon.py --src /path/to/glimmon_archive --dst /path/to/backups
+
+Optional args:
+    --filename   Name of the file to watch (default: G_LIMMON.dec)
+    --state-file Path to a state file to track last hash
+                 (default: <dst>/.glimmon_backup_state.json)
+"""
+
+import argparse
+import json
+import shutil
+from datetime import datetime
+from hashlib import sha256
+from pathlib import Path
+from typing import Dict
+
+
+def compute_hash(file_path: Path) -> str:
+    """
+    Return the SHA-256 hex digest of the given file.
+
+    Reads the file in 8KB chunks to avoid loading large files entirely into memory.
+    """
+    h = sha256()
+    with file_path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_state(state_path: Path) -> Dict[str, str]:
+    """
+    Load previously recorded hashes from the state file.
+
+    Returns an empty dict if the state file is missing or unreadable.
+    """
+    if not state_path.exists():
+        return {}
+    try:
+        return json.loads(state_path.read_text())
+    except Exception:
+        return {}
+
+
+def save_state(state_path: Path, state: Dict[str, str]) -> None:
+    """
+    Persist the hash state to disk as JSON.
+
+    Ensures the parent directory exists before writing.
+    """
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state, indent=2))
+
+
+def backup_if_changed(src_dir: Path, dst_dir: Path, filename: str, state_file: Path) -> None:
+    """
+    Compute the hash of the target file and back it up if contents have changed.
+
+    Compares the current hash to the last stored hash; when different, copies the
+    file to the destination with a timestamp and short-hash suffix, updates state,
+    and prints a short summary. No copy occurs if the hash matches the stored value.
+    """
+    src_file = src_dir / filename
+    if not src_file.exists():
+        raise FileNotFoundError(f"Source file not found: {src_file}")
+
+    dst_dir.mkdir(parents=True, exist_ok=True)
+
+    state = load_state(state_file)
+    current_hash = compute_hash(src_file)
+    last_hash = state.get(str(src_file))
+
+    if last_hash == current_hash:
+        print(f"No change detected for {src_file}; last hash matches current hash.")
+        return
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    short_hash = current_hash[:8]
+    dest_name = f"{src_file.stem}_{timestamp}_{short_hash}{src_file.suffix}"
+    dest_path = dst_dir / dest_name
+
+    shutil.copy2(src_file, dest_path)
+    state[str(src_file)] = current_hash
+    save_state(state_file, state)
+
+    print(f"Detected update. Copied {src_file} -> {dest_path}")
+    print(f"Hash: {current_hash}")
+
+
+def parse_args():
+    """
+    Parse CLI arguments for the backup script.
+
+    Supports source/destination directories, filename override, and custom state file.
+    """
+    parser = argparse.ArgumentParser(description="Backup G_LIMMON.dec when contents change.")
+    parser.add_argument("--src", required=True, help="Source directory containing G_LIMMON.dec")
+    parser.add_argument("--dst", required=True, help="Destination directory for backups")
+    parser.add_argument(
+        "--filename", default="G_LIMMON.dec", help="Filename to monitor (default: G_LIMMON.dec)"
+    )
+    parser.add_argument(
+        "--state-file",
+        default=None,
+        help="Path to state file (default: <dst>/.glimmon_backup_state.json)",
+    )
+    return parser.parse_args()
+
+
+def main():
+    """
+    Entrypoint: parse arguments, resolve paths, and trigger conditional backup.
+    """
+    args = parse_args()
+    src_dir = Path(args.src).expanduser()
+    dst_dir = Path(args.dst).expanduser()
+    state_file = (
+        Path(args.state_file).expanduser()
+        if args.state_file
+        else dst_dir / ".glimmon_backup_state.json"
+    )
+
+    backup_if_changed(src_dir, dst_dir, args.filename, state_file)
+
+
+if __name__ == "__main__":
+    main()
+
+# Additional Description:
+#
+# backup_glimmon.py flow:
+
+#  - main():
+#    - Calls parse_args() to read --src, --dst, optional --filename, optional --state-file.
+#    - Resolves paths (src_dir, dst_dir, state_file; default state file is 
+#      <dst>/.glimmon_backup_state.json).
+#    - Invokes backup_if_changed(src_dir, dst_dir, filename, state_file).
+
+#  - backup_if_changed(src_dir, dst_dir, filename, state_file):
+#    - Builds src_file = src_dir/filename; errors if missing.
+#    - Ensures dst_dir exists.
+#    - Loads prior hashes from state_file via load_state().
+#    - Computes current hash via compute_hash() (SHA-256 over 8KB chunks).
+#    - Compares current_hash to last_hash for src_file:
+#      - If unchanged: print “No change detected…” and return.
+#      - If changed:
+#        - Build timestamp (UTC, YYYYMMDD_HHMMSS) and short_hash (first 8 chars).
+#        - Copy src_file to dst_dir as <stem><timestamp><short_hash><suffix> using shutil.copy2.
+#        - Update state with the new hash and save it via save_state().
+#        - Print a summary with source, destination, and full hash.
+#
+#  - compute_hash(file_path):
+#    - Streams file contents into sha256() and returns the hex digest.
+#
+#  - load_state(state_path):
+#    - Loads JSON from the state file; returns {} if missing/unreadable.
+#
+#  - save_state(state_path, state):
+#    - Ensures parent directory exists, writes the state dict as JSON.
+#
+#  - parse_args():
+#    - Defines the CLI interface and returns parsed arguments.
+#
+# Net effect: each run checks the watched G_LIMMON.dec (or custom filename) for content changes; 
+# on change, it copies the file to the destination with a timestamp+short-hash suffix and records 
+# the new hash to avoid redundant backups.

--- a/demo_fingerprints.sh
+++ b/demo_fingerprints.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demonstrate deterministic database fingerprints persisted in build_fingerprints.
+# Requires GLIMMONDATA (or SKA_DATA) to point at the glimmon archive and allows glimmondb.py to run.
+
+CUSTOM_DIR="${1:-}"
+echo "==> Ensuring environment is set (GLIMMONDATA or SKA_DATA) or custom dir provided..."
+if [[ -n "${CUSTOM_DIR}" ]]; then
+  GLIMMON_DIR="${CUSTOM_DIR}"
+elif [[ -n "${GLIMMONDATA:-}" ]]; then
+  GLIMMON_DIR="${GLIMMONDATA}"
+elif [[ -n "${SKA_DATA:-}" ]]; then
+  GLIMMON_DIR="${SKA_DATA}/glimmon_archive"
+else
+  echo "ERROR: Provide a directory argument or set GLIMMONDATA (or SKA_DATA)." >&2
+  exit 1
+fi
+GLIMMON_DIR="$(cd "${GLIMMON_DIR}" && pwd)"
+
+DB_PATH="${GLIMMON_DIR}/glimmondb.sqlite3"
+
+if [[ ! -f "${DB_PATH}" ]]; then
+  echo "ERROR: Expected database at ${DB_PATH} not found. Create or recreate it first." >&2
+  exit 1
+fi
+
+echo "==> Latest fingerprint (compact for ~110-char terminal):"
+sqlite3 "${DB_PATH}" <<'SQL'
+.headers on
+.mode column
+.width 8 16 16 16 12 12 8 8 8 20
+SELECT version,
+       substr(limit_hash,1,14) || '..' AS limit_hash,
+       substr(state_hash,1,14) || '..' AS state_hash,
+       substr(version_hash,1,14) || '..' AS version_hash,
+       substr(db_sha256,1,12) || '..' AS db_sha,
+       db_size_bytes,
+       limit_count,
+       state_count,
+        version_count,
+        created_at
+FROM build_fingerprints
+ORDER BY version DESC
+LIMIT 1;
+SQL
+
+echo "==> Latest version record:"
+sqlite3 "${DB_PATH}" <<'SQL'
+.headers on
+.mode column
+SELECT version, datesec, date FROM versions ORDER BY version DESC LIMIT 1;
+SQL
+
+LOG_PATH="${GLIMMON_DIR}/DB_Commit.log"
+if [[ -f "${LOG_PATH}" ]]; then
+  echo "==> Recent fingerprint log entries (last few lines):"
+  rg -i "fingerprint|hash" -n "${LOG_PATH}" | tail -n 5 || true
+else
+  echo "Log file not found at ${LOG_PATH}; skipping log tail."
+fi
+
+echo "==> Done. Above hashes/counts should remain identical across recreations if inputs are unchanged."

--- a/glimmondb_tests.py
+++ b/glimmondb_tests.py
@@ -41,16 +41,17 @@ def querydatabase(glimmondbfile, datecheckbefore):
 
     cursor.execute('''SELECT msid, setkey, datesec, date, modversion, mlmenable, mlmtol, 
                       default_set, mlimsw, caution_high, caution_low, warning_high, warning_low,
-                      switchstate FROM limits WHERE datesec < ?''', (datecheckbefore,))
+                      switchstate FROM limits WHERE datesec < ? ORDER BY datesec, msid, setkey''',
+                   (datecheckbefore,))
     all_limits = cursor.fetchall()
 
     cursor.execute('''SELECT msid, setkey, datesec, date, modversion, mlmenable, mlmtol,
                       default_set, mlimsw, expst, switchstate FROM expected_states WHERE 
-                      datesec < ?''', (datecheckbefore,))
+                      datesec < ? ORDER BY datesec, msid, setkey''', (datecheckbefore,))
     all_states = cursor.fetchall()
 
-    cursor.execute('''SELECT version, datesec, date FROM versions WHERE datesec < ?''',
-                      (datecheckbefore,))
+    cursor.execute('''SELECT version, datesec, date FROM versions WHERE datesec < ? 
+                      ORDER BY datesec, version''', (datecheckbefore,))
     all_versions = cursor.fetchall()
 
     db.close()
@@ -89,26 +90,43 @@ def test_function():
     glimmondb.recreate_db(glimmondbfile='glimmondb_testing.sqlite3')
     copy('./testing_data/glimmondb_testing.sqlite3', './glimmondb_testing_backup.sqlite3')
 
+    # Recreate a second time to validate deterministic outputs across runs
+    glimmondb.recreate_db(glimmondbfile='glimmondb_testing_second.sqlite3')
+
     new_all_limits, new_all_states, new_all_versions = querydatabase(pathjoin(glimmondb.DBDIR, 
         'glimmondb_testing.sqlite3'), datecheckbefore)
+
+    new_all_limits_second, new_all_states_second, new_all_versions_second = querydatabase(
+        pathjoin(glimmondb.DBDIR, 'glimmondb_testing_second.sqlite3'), datecheckbefore)
 
     old_all_limits, old_all_states, old_all_versions = querydatabase(pathjoin(glimmondb.DBDIR, 
         'glimmondb.sqlite3'), datecheckbefore)
 
     saveoutputs(new_all_limits, new_all_states, new_all_versions, prestr='new')
-    saveoutputs(old_all_limits, old_all_states, old_all_versions, prestr='new')
+    saveoutputs(new_all_limits_second, new_all_states_second, new_all_versions_second,
+                prestr='new_second')
+    saveoutputs(old_all_limits, old_all_states, old_all_versions, prestr='old')
 
     newlimithash, newstatehash, newversionhash = gethashes(new_all_limits, new_all_states, 
                                                            new_all_versions)
+    newlimithash_second, newstatehash_second, newversionhash_second = gethashes(
+        new_all_limits_second, new_all_states_second, new_all_versions_second)
     oldlimithash, oldstatehash, oldversionhash = gethashes(old_all_limits, old_all_states,
                                                            old_all_versions)
 
     print(('newlimithash = {}\nnewstatehash = {}\nnewversionhash = {}'.format(newlimithash,
                                                                              newstatehash,
                                                                              newversionhash)))
+    print(('newlimithash_second = {}\nnewstatehash_second = {}\nnewversionhash_second = {}'
+           .format(newlimithash_second, newstatehash_second, newversionhash_second)))
     print(('oldlimithash = {}\noldstatehash = {}\noldversionhash = {}'.format(oldlimithash,
                                                                              oldstatehash,
                                                                              oldversionhash)))
+
+    # Deterministic across recreations
+    assert newlimithash == newlimithash_second
+    assert newstatehash == newstatehash_second
+    assert newversionhash == newversionhash_second
 
     assert oldlimithash == newlimithash
     assert oldstatehash == newstatehash

--- a/glimmondb_tests.py
+++ b/glimmondb_tests.py
@@ -30,6 +30,9 @@ try:
 except:
     print('Could not delete old log')
 import glimmondb
+from glimmondb import get_logger
+
+logger = get_logger(__name__, tabletype='test')
 
 print('\nRegenerated testing folder at: ./testing_data')
 print(('Using G_LIMMON Archive at: {}'.format(glimmondb.DBDIR)))
@@ -113,6 +116,19 @@ def test_function():
         new_all_limits_second, new_all_states_second, new_all_versions_second)
     oldlimithash, oldstatehash, oldversionhash = gethashes(old_all_limits, old_all_states,
                                                            old_all_versions)
+
+    logger.info('Computed hashes for new recreation', extra={'label': 'new',
+                                                             'limit_hash': newlimithash,
+                                                             'state_hash': newstatehash,
+                                                             'version_hash': newversionhash})
+    logger.info('Computed hashes for second recreation', extra={'label': 'new_second',
+                                                                'limit_hash': newlimithash_second,
+                                                                'state_hash': newstatehash_second,
+                                                                'version_hash': newversionhash_second})
+    logger.info('Computed hashes for existing database', extra={'label': 'existing',
+                                                                'limit_hash': oldlimithash,
+                                                                'state_hash': oldstatehash,
+                                                                'version_hash': oldversionhash})
 
     print(('newlimithash = {}\nnewstatehash = {}\nnewversionhash = {}'.format(newlimithash,
                                                                              newstatehash,

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,140 @@
+import os
+import sqlite3
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+TEST_DB_PATH = Path(os.environ.get("GLIMMON_TEST_DB", "testing_data/glimmondb.sqlite3"))
+
+# Fingerprints captured from the current testing_data/glimmondb.sqlite3.
+EXPECTED_FINGERPRINTS = {
+    "limit_hash": "03e11c97619fb3068d1af730c12d41c01ff44ee5c9613186d6ed838b04be93df",
+    "state_hash": "d24b4a66f89fedd8b59c123d32715eec31551962672cbc282b90c26379f41442",
+    "version_hash": "8a746b74d3f66e43e5326fc34d01b36ccd50c488cf3a72451b214bb58b58de83",
+    "limit_count": 4028,
+    "state_count": 2242,
+    "version_count": 422,
+}
+
+
+@pytest.fixture(scope="module")
+def db_conn():
+    if not TEST_DB_PATH.exists():
+        pytest.skip(f"Test database not found at {TEST_DB_PATH}")
+    conn = sqlite3.connect(TEST_DB_PATH)
+    yield conn
+    conn.close()
+
+
+def _hash_rows(rows):
+    return sha256(str(rows).encode("utf-8")).hexdigest()
+
+
+def test_max_version_positive(db_conn):
+    cursor = db_conn.cursor()
+    cursor.execute("SELECT MAX(version) FROM versions")
+    version = cursor.fetchone()[0]
+    assert version is not None and version > 0
+
+
+def test_limits_by_msid(db_conn):
+    cursor = db_conn.cursor()
+    cursor.execute("SELECT * FROM limits WHERE msid=?", ("tcylaft6",))
+    rows = cursor.fetchall()
+    assert rows, "Expected at least one row for msid tcylaft6"
+
+
+def test_latest_limits_all_msids_unique(db_conn):
+    cursor = db_conn.cursor()
+    cursor.execute(
+        """SELECT a.msid, a.setkey, a.caution_high, a.caution_low, a.warning_high, a.warning_low
+           FROM limits AS a
+           WHERE a.modversion = (SELECT MAX(b.modversion) FROM limits AS b
+                                 WHERE a.msid = b.msid AND a.setkey = b.setkey)"""
+    )
+    rows = cursor.fetchall()
+    assert rows, "Expected latest limits rows"
+    pairs = [(r[0], r[1]) for r in rows]
+    assert len(pairs) == len(set(pairs)), "Duplicate msid/setkey pairs found"
+
+
+def test_latest_limits_for_msid(db_conn):
+    cursor = db_conn.cursor()
+    cursor.execute(
+        """SELECT a.msid, a.setkey, a.mlmenable, a.caution_high, a.caution_low,
+                  a.warning_high, a.warning_low
+           FROM limits AS a
+           WHERE a.msid=? AND a.modversion = (SELECT MAX(b.modversion) FROM limits AS b
+                                              WHERE b.msid=a.msid)""",
+        ("tephin",),
+    )
+    rows = cursor.fetchall()
+    assert rows, "Expected rows for msid tephin"
+    for row in rows:
+        mlmenable = row[2]
+        assert mlmenable in (0, 1), f"mlmenable should be 0 or 1, got {mlmenable}"
+
+
+def test_latest_expected_states_all_msids_unique(db_conn):
+    cursor = db_conn.cursor()
+    cursor.execute(
+        """SELECT a.msid, a.setkey, a.expst
+           FROM expected_states AS a
+           WHERE a.modversion = (SELECT MAX(b.modversion) FROM expected_states AS b
+                                 WHERE a.msid = b.msid AND a.setkey = b.setkey)"""
+    )
+    rows = cursor.fetchall()
+    assert rows, "Expected latest expected_state rows"
+    pairs = [(r[0], r[1]) for r in rows]
+    assert len(pairs) == len(set(pairs)), "Duplicate msid/setkey pairs found"
+
+
+def test_latest_expected_state_for_msid(db_conn):
+    cursor = db_conn.cursor()
+    cursor.execute(
+        """SELECT a.msid, a.setkey, a.mlmenable, a.expst
+           FROM expected_states AS a
+           WHERE a.msid=? AND a.modversion = (SELECT MAX(b.modversion) FROM expected_states AS b
+                                              WHERE b.msid=a.msid)""",
+        ("ebt2rly3",),
+    )
+    rows = cursor.fetchall()
+    assert rows, "Expected rows for msid ebt2rly3"
+    for row in rows:
+        mlmenable = row[2]
+        assert mlmenable in (0, 1), f"mlmenable should be 0 or 1, got {mlmenable}"
+
+
+def test_fingerprints_match_expected(db_conn):
+    cursor = db_conn.cursor()
+
+    cursor.execute(
+        """SELECT msid, setkey, datesec, date, modversion, mlmenable, mlmtol,
+                  default_set, mlimsw, caution_high, caution_low, warning_high,
+                  warning_low, switchstate
+           FROM limits
+           ORDER BY datesec, msid, setkey"""
+    )
+    limit_rows = cursor.fetchall()
+    cursor.execute(
+        """SELECT msid, setkey, datesec, date, modversion, mlmenable, mlmtol,
+                  default_set, mlimsw, expst, switchstate
+           FROM expected_states
+           ORDER BY datesec, msid, setkey"""
+    )
+    state_rows = cursor.fetchall()
+    cursor.execute(
+        """SELECT version, datesec, date
+           FROM versions
+           ORDER BY datesec, version"""
+    )
+    version_rows = cursor.fetchall()
+
+    assert len(limit_rows) == EXPECTED_FINGERPRINTS["limit_count"]
+    assert len(state_rows) == EXPECTED_FINGERPRINTS["state_count"]
+    assert len(version_rows) == EXPECTED_FINGERPRINTS["version_count"]
+
+    assert _hash_rows(limit_rows) == EXPECTED_FINGERPRINTS["limit_hash"]
+    assert _hash_rows(state_rows) == EXPECTED_FINGERPRINTS["state_hash"]
+    assert _hash_rows(version_rows) == EXPECTED_FINGERPRINTS["version_hash"]


### PR DESCRIPTION
This includes a large number of updates intended to make the glimmon database maintenance more robust and include better tracking.

 - Added structured JSON logging with context-aware adapters, deterministic ordering for queries/merge ops, and persisted fingerprints (hashes/counts/file hashes) to the new build_fingerprints table; integrated fingerprint computation after ingestions and provided a demo script for viewing them (glimmondb.py, demo_fingerprints.sh).
 - Ensured deterministic DB recreation by ordering queries and sorting diffs; added pytest coverage for key queries and fingerprint hashes against the test DB (tests/test_queries.py).
 - Introduced a backup utility to detect and copy updated G_LIMMON.dec files with hash/timestamp suffixes, plus docstrings (backup_glimmon.py).
 - Simplified project ignore rules to exclude test data, Python caches, and editor/OS cruft (.gitignore).

Tests: pytest (relies on testing_data/glimmondb.sqlite3 fingerprints).