### PR TITLE
Fix too many files open error caused by logging changes

### DIFF
--- a/glimmondb/glimmondb.py
+++ b/glimmondb/glimmondb.py
@@ -29,7 +29,7 @@ def _require_path(primary_var, fallback_var=None, fallback_suffix=None):
 DBDIR = _require_path('GLIMMONDATA', 'SKA_DATA', 'glimmon_archive')
 TDBDIR = _require_path('TDBDATA', 'SKA_DATA', 'fot_tdb_archive')
 
-logfile = pathjoin(str(DBDIR), 'DB_Commit.log')
+logfile = str((Path(DBDIR) / 'DB_Commit.log').resolve())
 
 logging.getLogger("glimmondb").addHandler(logging.NullHandler())
 

--- a/glimmondb/version.py
+++ b/glimmondb/version.py
@@ -1,3 +1,3 @@
 __all__ = ['__version__']
 
-__version__ = '0.8.1'
+__version__ = '0.8.2'


### PR DESCRIPTION
This was a result of an issue between relative and absolute paths when looking for the log file. The changes force all log file paths to be absolute.